### PR TITLE
Externally defining the docker network for Jupyter containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Checkout Code Repository
         uses: actions/checkout@v4
 
+      - name: Create the docker network
+        run: ./compose/create-network.sh
+
       - name: Build the Stack
         run: docker compose -f docker-compose.local.yml build django
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,50 @@ Visualization platform for the SpectrumX project
 
 License: MIT
 
-## Settings
+## Deployment
 
-Moved to [settings](http://cookiecutter-django.readthedocs.io/en/latest/settings.html).
+Docker Compose is the recommended deployment method for this project.
+
+### Create secrets
+
+If using the production deployment, create the secrets files:
+
+```bash
+rsync -aP .envs/.local/ .envs/.production/
+```
+
+Then set the secrets that will be used by the SVI services in these files.
+
+### Creating the network
+
+This will create an external network so that jupyter containers not in the compose files
+can reattach to when the services are restarted.
+
+```bash
+./compose/create-network.sh
+```
+
+### Switching environments
+
+To select the environment, set the `COMPOSE_FILE` environment variable to the desired
+docker-compose file, i.e.:
+
+```bash
+# for development:
+export COMPOSE_FILE=docker-compose.local.yml
+
+# for production:
+export COMPOSE_FILE=docker-compose.production.yml
+```
+
+Then proceed with other compose commands.
+
+```bash
+docker compose build
+docker compose up
+docker compose down
+docker compose logs -f
+```
 
 ## Basic Commands
 
@@ -19,7 +60,9 @@ Moved to [settings](http://cookiecutter-django.readthedocs.io/en/latest/settings
 
 - To create a **superuser account**, use this command:
 
-      $ python manage.py createsuperuser
+```bash
+python manage.py createsuperuser
+```
 
 For convenience, you can keep your normal user logged in on Chrome and your superuser logged in on Firefox (or similar), so that you can see how the site behaves for both kinds of users.
 
@@ -27,19 +70,25 @@ For convenience, you can keep your normal user logged in on Chrome and your supe
 
 Running type checks with mypy:
 
-    $ mypy spectrumx_visualization_platform
+```bash
+mypy spectrumx_visualization_platform
+```
 
 ### Test coverage
 
 To run the tests, check your test coverage, and generate an HTML coverage report:
 
-    $ coverage run -m pytest
-    $ coverage html
-    $ open htmlcov/index.html
+```bash
+coverage run -m pytest
+coverage html
+open htmlcov/index.html
+```
 
 #### Running tests with pytest
 
-    $ pytest
+```bash
+pytest
+```
 
 ### Live reloading and Sass CSS compilation
 
@@ -72,14 +121,6 @@ cd spectrumx_visualization_platform
 celery -A config.celery_app worker -B -l info
 ```
 
-## Deployment
-
-The following details how to deploy this application.
-
-### Docker
-
-See detailed [cookiecutter-django Docker documentation](http://cookiecutter-django.readthedocs.io/en/latest/deployment-with-docker.html).
-
 ## Auth0
 
 See detailed [Auth0 documentation](https://auth0.com/docs).
@@ -88,22 +129,21 @@ See detailed [Auth0 documentation](https://auth0.com/docs).
 
 1. Modify the `requirements/base.txt` to include `socialaccount` in `django-allauth`
 
-```
+```ini
 django-allauth[socialaccount]==65.0.2  # https://github.com/pennersr/django-allauth
 fido2==1.1.3  # https://github.com/Yubico/python-fido2
 ```
 
 2. Add Environment Variables to `.envs/.local/.django`
 
-```
-
+```bash
 # Auth0
 AUTH0_DOMAIN=https://[DOMAIN].us.auth0.com
 ```
 
 3. Add Auth0 to `config/settings/base.py`
 
-```
+```py
 # Auth0 Configuration
 SOCIALACCOUNT_PROVIDERS = {
     "auth0": {

--- a/compose/create-network.sh
+++ b/compose/create-network.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Defines a standalone docker network for jupyter containers to attach to.
+# Run this before running `docker compose up` or similar.
+# You may run this script multiple times.
+
+set -euo pipefail
+
+NETWORK_NAME="${1:-spectrumx_network}"
+QUIET="false"
+
+function _log() {
+    ts=$(date +"%Y-%m-%d %H:%M:%S")
+    if [ "${QUIET}" = "false" ]; then
+        echo -e "${ts} | ${1}"
+    fi
+}
+
+function log_info() {
+    _log "\033[0;34m${1}\033[0m"
+}
+
+function main() {
+
+    if ! docker network inspect "${NETWORK_NAME}" >/dev/null 2>&1; then
+        docker network create \
+            --driver bridge \
+            --attachable \
+            --internal=false \
+            "${NETWORK_NAME}"
+        log_info "Created docker network '${NETWORK_NAME}':"
+    else
+        log_info "Network '${NETWORK_NAME}' already exists, skipping creation:"
+    fi
+
+    inspect_cmd="docker network inspect ${NETWORK_NAME}"
+    if [ "${QUIET}" = "false" ]; then
+        # run inspect to show the network details
+        if command -v jq >/dev/null 2>&1; then
+            ${inspect_cmd} | jq .
+        else
+            ${inspect_cmd}
+        fi
+    else
+        # run inspect just to get the return code
+        ${inspect_cmd} >/dev/null 2>&1
+    fi
+
+}
+
+main "$@"

--- a/compose/production/jupyter/Dockerfile
+++ b/compose/production/jupyter/Dockerfile
@@ -5,7 +5,7 @@ FROM quay.io/jupyterhub/jupyterhub:$JUPYTERHUB_VERSION
 
 
 # Install Python packages from requirements.txt
-COPY ./compose/local/jupyter/requirements.txt /tmp/requirements.txt
+COPY ./compose/production/jupyter/requirements.txt /tmp/requirements.txt
 RUN python3 -m pip install --no-cache-dir -r /tmp/requirements.txt
 
 CMD ["jupyterhub", "-f", "/srv/jupyterhub/jupyterhub_config.py"]

--- a/compose/production/jupyter/jupyterhub_config.py
+++ b/compose/production/jupyter/jupyterhub_config.py
@@ -1,6 +1,8 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+# API reference: https://jupyterhub-dockerspawner.readthedocs.io/en/latest/api/index.html
+
 # Configuration file for JupyterHub
 import os
 
@@ -110,4 +112,4 @@ c.DockerSpawner.extra_host_config = {
 }
 
 # Replace with a proper shell command that handles errors
-c.DockerSpawner.post_start_cmd = "pip install spectrumx"
+c.DockerSpawner.post_start_cmd = "pip install ipywidgets spectrumx"

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -132,11 +132,6 @@ services:
       - spectrumx_network
 
 networks:
+  # run ./compose/create-network.sh first to create this network
   spectrumx_network:
-    driver: bridge
-    name: spectrumx_network
-    external: false
-    ipam:
-      driver: default
-      config:
-        - subnet: 172.28.0.0/16
+    external: true

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -155,9 +155,6 @@ services:
       - ./.envs/.production/.jupyterhub
 
 networks:
+  # run ./compose/create-network.sh first to create this network
   spectrumx_network:
-    driver: bridge
-    name: spectrumx_network
-    # Add these configurations to ensure the network is properly created
-    external: false
-    attachable: true
+    external: true


### PR DESCRIPTION
[SFV-122](https://crc-dev.atlassian.net/browse/SFV-122)

- Externally defining `spectrumx_network` to allow its reuse and the reattachment of Jupyter containers not defined in compose files.
- Updated README to focus on Docker commands.
- Updated README to guide users to create the network before running the containers.
- Installing `ipywidgets` along with `spectrumx` by default: this prevents a warning when importing spectrumx; likely stemming from `tqdm` (used for progress bars).
